### PR TITLE
Req. 6 - Don't grab crate if it already lifting one

### DIFF
--- a/app/domains/operational/grabbing_service.rb
+++ b/app/domains/operational/grabbing_service.rb
@@ -7,6 +7,8 @@ module Operational
     def call(robot:)
       return unless robot
 
+      return if robots_repo.holding_crate?(robot)
+
       robots_repo.grab_crate(robot)
     end
   end

--- a/app/domains/repositories/robots/active_record_adaptor.rb
+++ b/app/domains/repositories/robots/active_record_adaptor.rb
@@ -35,6 +35,8 @@ module Repositories
         robot.crate = nil
       end
 
+      def holding_crate?(robot); end
+
       def save(robot)
         robot.save!
       end

--- a/app/domains/repositories/robots/active_record_adaptor.rb
+++ b/app/domains/repositories/robots/active_record_adaptor.rb
@@ -35,7 +35,9 @@ module Repositories
         robot.crate = nil
       end
 
-      def holding_crate?(robot); end
+      def holding_crate?(robot)
+        robot.crate.present?
+      end
 
       def save(robot)
         robot.save!

--- a/app/domains/repositories/robots/base.rb
+++ b/app/domains/repositories/robots/base.rb
@@ -31,6 +31,10 @@ module Repositories
         raise 'Not implemented yet'
       end
 
+      def holding_crate?(_robot)
+        raise 'Not implemented yet'
+      end
+
       def save
         raise 'Not implemented yet'
       end

--- a/spec/domains/operational/grabbing_service_spec.rb
+++ b/spec/domains/operational/grabbing_service_spec.rb
@@ -5,8 +5,9 @@ require 'rails_helper'
 RSpec.describe Operational::GrabbingService do
   subject(:drop_service) { described_class.new(robots_repo: repo) }
 
-  let(:repo) { instance_double Repositories::Robots::Base, grab_crate: nil }
-  let(:robot) { create :robot }
+  let(:repo) { instance_double Repositories::Robots::Base, grab_crate: nil, holding_crate?: crate }
+  let(:robot) { build(:robot) }
+  let(:crate) { false }
 
   describe '#call' do
     before { drop_service.call(robot: robot) }
@@ -17,6 +18,14 @@ RSpec.describe Operational::GrabbingService do
 
     context 'without a robot' do
       let(:robot) { nil }
+
+      it 'does not call the robots repository' do
+        expect(repo).not_to have_received(:grab_crate).with(robot)
+      end
+    end
+
+    context 'with a robot already holding a crate' do
+      let(:crate) { true }
 
       it 'does not call the robots repository' do
         expect(repo).not_to have_received(:grab_crate).with(robot)

--- a/spec/domains/repositories/robots/active_record_adaptor_spec.rb
+++ b/spec/domains/repositories/robots/active_record_adaptor_spec.rb
@@ -86,4 +86,22 @@ RSpec.describe Repositories::Robots::ActiveRecordAdaptor do
       expect { repo.drop_crate(robot) }.to change(crate, :robot).from(robot).to(nil)
     end
   end
+
+  describe '#holding_crate?' do
+    context 'when holding a crate' do
+      let(:robot) { create :robot, :holding_crate }
+
+      it 'returns true' do
+        expect(repo).to be_holding_crate(robot)
+      end
+    end
+
+    context 'when not holding a crate' do
+      let(:robot) { create :robot }
+
+      it 'returns false' do
+        expect(repo).not_to be_holding_crate(robot)
+      end
+    end
+  end
 end


### PR DESCRIPTION
# Description

Introduce rules to the domain to deal with

> (Req 6.) The robot should not try and lift a crate if it already lifting one

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

- [x] My code does not impact our test coverage 
- [x] My code follows the style guidelines of this project
- [x] I have followed a TDD approach to write my tests
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

